### PR TITLE
fix: wrong path

### DIFF
--- a/inference_video.py
+++ b/inference_video.py
@@ -81,7 +81,7 @@ def inference_video(engines, ref_img_path, drive_video_path, save_path, trans_ra
     ff_cat_video_and_audio(save_path, drive_video_path, osp.splitext(save_path)[0] + '_audio.mp4')
 
 if __name__ == '__main__':
-    ref_img_path = r"data/reference_images/trump1.jpg"
+    ref_img_path = r"data/reference_images/trump.jpg"
     drive_video_path = r"data/drive_videos/jue.mp4"
     save_dir = r'data/results'
 


### PR DESCRIPTION
Great work! Thank you to the authors for open-sourcing it!

I found a small bug: the default path for images is incorrect. I have submitted a PR to correct the path.

Additionally, I encountered a few issues while setting up the environment that the authors might want to consider:

Running `pip install onnxruntime` installs the CPU version by default; it's better to specify `onnxruntime-gpu`.
`scipy` and `imageio[ffmpeg]` are missing and need to be installed manually.
On my Linux machine, the following versions work well: `scipy==1.14.1, onnxruntime-gpu==1.18.0, and numpy==1.21.6`.

Very interesting work! :)